### PR TITLE
Disable Redirects

### DIFF
--- a/src/SproutSeo.php
+++ b/src/SproutSeo.php
@@ -154,7 +154,7 @@ class SproutSeo extends Plugin
         });
 
         Event::on(ErrorHandler::class, ErrorHandler::EVENT_BEFORE_HANDLE_EXCEPTION, function(ExceptionEvent $event) {
-            if ($this->is(self::EDITION_PRO)) {
+            if ($this->is(self::EDITION_PRO) && $settings->enableRedirects) {
                 SproutBaseRedirects::$app->redirects->handleRedirectsOnException($event);
             }
         });


### PR DESCRIPTION
Hi! We love the plugin, but I have run into issues with the redirects feature for our multisite Craft installation. I would like to "actually" disable the Redirects portion of the plugin, but still use the SEO meta data, etc., portion of it. 

URL exceptions are still routed through the redirects portion even if "redirects" is disabled from the admin panel, which has resulted in some miscellaneous goofs, especially when attempting to write Codeception tests.

I understand that the exact phrasing of the setting is:
> Disabled items will be removed from the sidebar navigation and no longer accessible in the Control Panel.

However, I would still like to have any handling of redirects disabled (not just in the admin panel), and there appears no way to do so. This single line edit addresses the handling of exceptions when the redirects portion is disabled, allowing me to clear through the issues with writing tests, but does not do anything about legacy redirects, if present.

I'm open to feedback, but would still like to see the ability to disable handling of redirects by the plugin if possible.

Thanks!