### PR TITLE
backwards compatibility for checking "is_iterable"

### DIFF
--- a/src/services/ElementMetadata.php
+++ b/src/services/ElementMetadata.php
@@ -183,7 +183,7 @@ class ElementMetadata extends Component
 
             $handles = $this->getFieldHandles($targetSetting['value']);
 
-            if (is_iterable($handles)) {
+            if (is_array( $handles ) || ( is_object( $handles ) && ( $handles instanceof \Traversable ) )) {
                 foreach ($handles as $handle) {
                     if (isset($seoFieldHandles[$handle])) {
                         continue;


### PR DESCRIPTION
instead of using the function is_iterable, which is supported in PHP 7.1 or above, this set of tests reproduces the intended functionality